### PR TITLE
Add docker registry initialization and fix docker-init without registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -170,6 +170,9 @@ COPY known_hosts /etc/skel/.ssh/
 COPY kubeconfig /etc/skel/.kube/config
 RUN chmod 0600 /etc/skel/.pgpass
 RUN useradd -m -G sudo,users -s /bin/bash -u 2000 ii
+
+COPY bin/* /usr/local/bin/
+
 USER ii
 
 # # Fetch Golang dependencies for development
@@ -205,6 +208,3 @@ HEALTHCHECK --interval=10s --timeout=5s --start-period=5s --retries=5 \
   # but still enabling the repo should someone need it later
   # kubectl \
   # google-cloud-sdk \
-USER root
-COPY bin/* /usr/local/bin/
-USER ii

--- a/bin/docker-init.sh
+++ b/bin/docker-init.sh
@@ -180,6 +180,14 @@ if ! kubectl cluster-info 2>&1 > /dev/null; then
 fi
 
 if [ "$KIND_LOCAL_REGISTRY_ENABLE" = true ]; then
+    docker pull registry:2
+    running="$(docker inspect -f '{{.State.Running}}' "${KIND_LOCAL_REGISTRY_NAME}" 2>/dev/null || true)"
+    if [ ! "${running}" = 'true' ]; then
+        echo "[status] bringing up a local Docker registry"
+        execPrintOutputIfFailure docker run \
+               -d --restart=always -p "${KIND_LOCAL_REGISTRY_PORT}:5000" --name "${KIND_LOCAL_REGISTRY_NAME}" \
+               registry:2
+    fi
     echo "[status] ensuring nodes refer to the local Docker registry"
     # add the registry to /etc/hosts on each node
     ip_fmt='{{.NetworkSettings.IPAddress}}'


### PR DESCRIPTION
# Issues
- the `docker-init.sh` script was failing if registry is disabled
- Docker registry doesn't automatically initialize if it's enabled in `docker-init.sh`
